### PR TITLE
Improve expense list layout

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -13,6 +13,7 @@ header {
     background-color: white;
     padding: 30px;
     border-radius: 20px;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.15);
 }
 .presupuesto p{
     margin-bottom: 0;
@@ -35,4 +36,51 @@ h2 {
     color:#004e92;
     font-size: 22px;
     margin-bottom:30px;
+}
+
+#resetear{
+    font-weight: bold;
+}
+
+.table tbody tr.fade-in {
+    animation: fadeIn 0.5s ease;
+}
+
+.table tbody tr:hover {
+    background-color: #f8f9fa;
+}
+
+.table td,
+.table th {
+    vertical-align: middle;
+}
+
+.table td:last-child {
+    width:1%;
+    white-space: nowrap;
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(-5px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+#barra-progreso {
+    transition: width 0.4s ease;
+    font-weight: bold;
+}
+
+.progress {
+    height: 1.5rem;
+}
+
+#ingresar-presupuesto input {
+    max-width: 200px;
+    margin-right: 5px;
 }

--- a/index.html
+++ b/index.html
@@ -16,6 +16,15 @@
                 <h1 class="text-center">Gasto Semanal</h1>
         </header>
         <section class="contenido-principal">
+            <div id="ingresar-presupuesto" class="my-3 d-none">
+                <form id="form-presupuesto" class="form-inline justify-content-center">
+                    <div class="form-group mx-sm-3 mb-2">
+                        <label for="presupuesto-input" class="sr-only">Presupuesto</label>
+                        <input type="number" class="form-control" id="presupuesto-input" placeholder="Ingresa tu presupuesto">
+                    </div>
+                    <button type="submit" class="btn btn-success mb-2">Guardar</button>
+                </form>
+            </div>
             <div class="row">
                 <div class="col ">
                     <div class="contenido primario">
@@ -29,6 +38,11 @@
                                     <label for="cantidad">Cantidad:</label>
                                     <input type="text" class="form-control" id="cantidad" placeholder="Cantidad en $">
                                 </div>
+                                <div class="form-group">
+                                    <label for="categoria">Categoría:</label>
+                                    <input list="lista-categorias" type="text" class="form-control" id="categoria" placeholder="Ej. Transporte">
+                                    <datalist id="lista-categorias"></datalist>
+                                </div>
 
                                 <button type="submit" class="btn btn-primary">Agregar</button>
                             </form>
@@ -40,9 +54,18 @@
                     <div class="contenido secundario">
 
                         <h2 class="text-center">Listado</h2>
-
-                        <div id="gastos">
-                            <ul class="list-group"></ul>
+                        <div id="gastos" class="table-responsive">
+                            <table class="table table-striped">
+                                <thead>
+                                    <tr>
+                                        <th>Gasto</th>
+                                        <th>Categoría</th>
+                                        <th class="text-right">Cantidad</th>
+                                        <th></th>
+                                    </tr>
+                                </thead>
+                                <tbody></tbody>
+                            </table>
                         </div>
                         <div id="presupuesto" class="presupuesto">
                             <div class="alert alert-primary">
@@ -51,7 +74,11 @@
                             <div class="restante alert alert-success">
                                 <p>Restante: $ <span id="restante"></span></p>
                             </div>
-                        </div> <!--.presupuesto-->
+                            <div class="progress mt-2">
+                                <div id="barra-progreso" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width:0%;"></div>
+                            </div>
+                            <button id="resetear" class="btn btn-warning btn-block mt-3">Resetear</button>
+        </div> <!--.presupuesto-->
                     </div> <!--.contenido-->
                 </div><!--.col-->
             </div> <!--.row-->

--- a/js/app.js
+++ b/js/app.js
@@ -1,14 +1,29 @@
 // variables y selectores
 const formulario = document.querySelector('#agregar-gasto');
-const gastoListado = document.querySelector('#gastos ul');
+const gastoListado = document.querySelector('#gastos tbody');
+const categoriaInput = document.querySelector('#categoria');
+const categoriaDatalist = document.querySelector('#lista-categorias');
+const btnResetear = document.querySelector('#resetear');
+const barraProgreso = document.querySelector('#barra-progreso');
+const presupuestoForm = document.querySelector('#form-presupuesto');
+const presupuestoInput = document.querySelector('#presupuesto-input');
+const seccionPresupuesto = document.querySelector('#ingresar-presupuesto');
+const nombreInput = document.querySelector('#gasto');
+const cantidadInput = document.querySelector('#cantidad');
 
 //eventos
 eventListeners();
 
 function eventListeners(){
-    document.addEventListener('DOMContentLoaded', preguntarPresupuesto );
-
-    formulario.addEventListener('submit', agregarGasto)
+    document.addEventListener('DOMContentLoaded', cargarPresupuesto );
+    formulario.addEventListener('submit', agregarGasto);
+    if(presupuestoForm){
+        presupuestoForm.addEventListener('submit', definirPresupuesto);
+    }
+    if(btnResetear){
+        btnResetear.addEventListener('click', resetearApp);
+    }
+    // no category filter events
 };
 
 //clases
@@ -68,31 +83,34 @@ class UI{
     mostrarGastos(gastos){
         this.limpiarHTML(); //eliminar el html previo
 
-        //iterar sobre gastos
         gastos.forEach( gasto => {
-            const { cantidad, nombre, id} = gasto;
-            //crear un LI listado
-            const nuevoGasto = document.createElement('li');
-            nuevoGasto.className = 'list-group-item d-flex justify-content-between align-items-center';
-            //nuevoGasto.setAttribute('data-id', id);
-            nuevoGasto.dataset.id = id;
+            const { cantidad, nombre, categoria, id} = gasto;
+            const fila = document.createElement('tr');
+            fila.classList.add('fade-in');
+            fila.dataset.id = id;
 
-            //agregar al html
-            nuevoGasto.innerHTML = `${nombre} <span class="badge badge-primary badge-pill">$ ${cantidad}</span>`
+            const tdNombre = document.createElement('td');
+            tdNombre.textContent = nombre;
+            fila.appendChild(tdNombre);
 
-            //boton para borrar gasto
+            const tdCategoria = document.createElement('td');
+            tdCategoria.textContent = categoria;
+            fila.appendChild(tdCategoria);
+
+            const tdCantidad = document.createElement('td');
+            tdCantidad.classList.add('text-right');
+            tdCantidad.textContent = `$ ${cantidad}`;
+            fila.appendChild(tdCantidad);
+
+            const tdAcciones = document.createElement('td');
             const btnBorrar = document.createElement('button');
             btnBorrar.classList.add('btn', 'btn-danger', 'borrar-gasto');
             btnBorrar.innerHTML = 'Borrar &times';
-            btnBorrar.onclick = () =>{
-                eliminarGasto(id);
-            }
-            nuevoGasto.appendChild(btnBorrar);
+            btnBorrar.onclick = () => eliminarGasto(id);
+            tdAcciones.appendChild(btnBorrar);
+            fila.appendChild(tdAcciones);
 
-            //agregar al html
-            gastoListado.appendChild(nuevoGasto);
-
-
+            gastoListado.appendChild(fila);
         });
     }
     limpiarHTML(){
@@ -110,15 +128,15 @@ class UI{
         const restanteDiv = document.querySelector('.restante');
         //comprobar 25%
         if(( presupuesto / 4 ) > restante ){
-            restanteDiv.classList.remove('alert-succes', 'alert-warning');
+            restanteDiv.classList.remove('alert-success', 'alert-warning');
             restanteDiv.classList.add('alert-danger');
         //comprobar 50%
         }else if(( presupuesto / 2 ) > restante ){
-            restanteDiv.classList.remove('alert-succes');
+            restanteDiv.classList.remove('alert-success');
             restanteDiv.classList.add('alert-warning'); 
         }else{
             restanteDiv.classList.remove('alert-danger','alert-warning');
-            restanteDiv.classList.add('alert-succes'); 
+            restanteDiv.classList.add('alert-success');
         }
         //si el total es cero o menor
         if(restante <= 0 ){
@@ -134,16 +152,87 @@ let presupuesto;
 
 
 //funciones
-function preguntarPresupuesto(){
-    const presupuestoUsuario = prompt('¿Cual es tu presupuesto?');
+function cargarPresupuesto(){
+    const presupuestoLS = localStorage.getItem('presupuesto');
+    const gastosLS = localStorage.getItem('gastos');
 
-    if(presupuestoUsuario === '' || presupuestoUsuario === null || isNaN(presupuestoUsuario) || presupuestoUsuario <= 0){
-        window.location.reload();
+    if(presupuestoLS){
+        presupuesto = new Presupuesto(presupuestoLS);
+        presupuesto.gastos = gastosLS ? JSON.parse(gastosLS) : [];
+        presupuesto.calcularRestante();
+
+        ui.insertarPresupuesto(presupuesto);
+        actualizarCategorias();
+        actualizarBarra();
+        ui.actualizarRestante(presupuesto.restante);
+        ui.comprobarPresupuesto(presupuesto);
+        filtrarGastos();
+        seccionPresupuesto.classList.add('d-none');
+    }else{
+        preguntarPresupuesto();
     }
-    //presupuesto valido
-    presupuesto = new Presupuesto(presupuestoUsuario);
+}
 
+function sincronizarStorage(){
+    localStorage.setItem('presupuesto', presupuesto.presupuesto);
+    localStorage.setItem('gastos', JSON.stringify(presupuesto.gastos));
+}
+
+function resetearApp(){
+    localStorage.removeItem('presupuesto');
+    localStorage.removeItem('gastos');
+    window.location.reload();
+}
+
+function actualizarBarra(){
+    const gastado = presupuesto.presupuesto - presupuesto.restante;
+    const porcentaje = (gastado / presupuesto.presupuesto) * 100;
+    barraProgreso.style.width = `${porcentaje}%`;
+    barraProgreso.textContent = `${porcentaje.toFixed(0)}%`;
+    barraProgreso.classList.remove('bg-success','bg-warning','bg-danger');
+    if(porcentaje >= 75){
+        barraProgreso.classList.add('bg-danger');
+    }else if(porcentaje >= 50){
+        barraProgreso.classList.add('bg-warning');
+    }else{
+        barraProgreso.classList.add('bg-success');
+    }
+}
+
+function actualizarCategorias(){
+    const categorias = [...new Set(presupuesto.gastos.map(g => g.categoria).filter(Boolean))];
+    if(categoriaDatalist){
+        categoriaDatalist.innerHTML = '';
+        categorias.forEach(cat => {
+            const option = document.createElement('option');
+            option.value = cat;
+            categoriaDatalist.appendChild(option);
+        });
+    }
+}
+
+function filtrarGastos(){
+    ui.mostrarGastos(presupuesto.gastos);
+}
+
+function preguntarPresupuesto(){
+    seccionPresupuesto.classList.remove('d-none');
+}
+
+function definirPresupuesto(e){
+    e.preventDefault();
+    const presupuestoUsuario = Number(presupuestoInput.value);
+
+    if(presupuestoUsuario <= 0 || isNaN(presupuestoUsuario)){
+        ui.imprimirAlerta('Cantidad no valida', 'error');
+        return;
+    }
+    presupuesto = new Presupuesto(presupuestoUsuario);
     ui.insertarPresupuesto(presupuesto);
+    sincronizarStorage();
+    actualizarBarra();
+    seccionPresupuesto.classList.add('d-none');
+    presupuestoForm.reset();
 }
 
 //añade gastos
@@ -152,8 +241,9 @@ function agregarGasto(e){
     e.preventDefault();
 
     //leer los datos del formulario
-    const nombre = document.querySelector('#gasto').value;
-    const cantidad = Number(document.querySelector('#cantidad').value);
+    const nombre = nombreInput.value;
+    const cantidad = Number(cantidadInput.value);
+    const categoria = categoriaInput.value;
 
     //validar
     if(nombre ==='' || cantidad === ''){
@@ -166,20 +256,21 @@ function agregarGasto(e){
 
     //generar un objeto gasto un object literal
     //esta sintaxis une nombre y cantidad a gasto
-    const gasto = { nombre, cantidad, id: Date.now() };
+    const gasto = { nombre, cantidad, categoria, id: Date.now() };
     //añade gasto
     presupuesto.nuevoGasto( gasto );
 
     //mensaje de correcto
     ui.imprimirAlerta('Gasto agregado correctamente');
 
-    //imprimir los gastos
+
     const { gastos, restante } = presupuesto;
-    ui.mostrarGastos(gastos);
-
+    sincronizarStorage();
+    actualizarCategorias();
+    actualizarBarra();
     ui.actualizarRestante(restante);
-
     ui.comprobarPresupuesto(presupuesto);
+    filtrarGastos();
 
     //reinicia el formulario
     formulario.reset();
@@ -192,12 +283,12 @@ function eliminarGasto(id){
     //este los elimina del objeto
     presupuesto.eliminarGasto(id);
 
-    //elimina los gastos del html
     const { gastos, restante } = presupuesto;
-    ui.mostrarGastos(gastos);
-
+    sincronizarStorage();
+    actualizarCategorias();
+    actualizarBarra();
     ui.actualizarRestante(restante);
-
     ui.comprobarPresupuesto(presupuesto);
+    filtrarGastos();
 
 }


### PR DESCRIPTION
## Summary
- replace unordered list with table for cleaner expense layout
- remove unused category filter dropdown
- keep category datalist and progress bar
- add shared constants for gasto and cantidad inputs

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684da313a5e4832aa16aeb1903e168e1